### PR TITLE
Add payroll entry auto slip generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,4 @@
 ### Added
 - Salary slip creation now forces `tax_calculation_method` to "Manual" and clears `income_tax_slab`.
 - Renamed `use_ter_method` field on Payroll Entry to `ter_method_enabled`.
+- Payroll Entry submission now automatically creates and submits Salary Slips.

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ The Payroll Indonesia module is modularly optimized to provide top performance a
 
 ## 📁 Module Structure
 
-* **📋 Payroll Entry:** Enhanced validation, automated Salary Slip integration.
+* **📋 Payroll Entry:** Enhanced validation, automated Salary Slip integration. Salary Slips are generated automatically when the entry is submitted.
 * **📃 Salary Slip:** Modular overrides for BPJS and PPh21 salary calculations.
 * **📊 Salary Structure:** Wildcard company ('%') functionality, automatic GL account mappings.
 * **👥 Employee & Auth Hooks:** Robust employee data validation, Indonesian region-specific user session integration.

--- a/payroll_indonesia/hooks.py
+++ b/payroll_indonesia/hooks.py
@@ -60,6 +60,13 @@ doc_events = {
     "Payment Entry": {
         "on_submit": "payroll_indonesia.payroll_indonesia.doctype.bpjs_payment_summary.payment_hooks.on_payment_entry_submit",
     },
+    "Payroll Entry": {
+        "before_validate": "payroll_indonesia.override.payroll_entry_functions.before_validate",
+        "validate": "payroll_indonesia.override.payroll_entry_functions.validate",
+        "before_submit": "payroll_indonesia.override.payroll_entry_functions.before_submit",
+        "on_submit": "payroll_indonesia.override.payroll_entry_functions.on_submit",
+        "after_submit": "payroll_indonesia.override.payroll_entry_functions.after_submit",
+    },
 }
 
 # ❸ Override DocType classes

--- a/payroll_indonesia/override/payroll_entry_functions.py
+++ b/payroll_indonesia/override/payroll_entry_functions.py
@@ -29,7 +29,7 @@ from payroll_indonesia.constants import (
 def before_validate(doc, method=None):
     """
     Before validate hook for Payroll Entry.
-    
+
     Args:
         doc: Payroll Entry document
         method: Method name (not used)
@@ -38,16 +38,18 @@ def before_validate(doc, method=None):
         # Skip if document is already validated
         if hasattr(doc, "flags") and getattr(doc.flags, "skip_indonesia_hooks", False):
             return
-        
+
         # Only process if Indonesia payroll is enabled
         if cint(getattr(doc, "calculate_indonesia_tax", 0)) != 1:
             return
-        
+
         # Handle December override
         _check_december_override(doc)
-        
-        logger.debug(f"Completed before_validate for payroll entry {getattr(doc, 'name', 'unknown')}")
-    
+
+        logger.debug(
+            f"Completed before_validate for payroll entry {getattr(doc, 'name', 'unknown')}"
+        )
+
     except Exception as e:
         logger.exception(f"Error in before_validate: {str(e)}")
 
@@ -55,7 +57,7 @@ def before_validate(doc, method=None):
 def validate(doc, method=None):
     """
     Validate hook for Payroll Entry.
-    
+
     Args:
         doc: Payroll Entry document
         method: Method name (not used)
@@ -64,16 +66,16 @@ def validate(doc, method=None):
         # Skip if document is already validated
         if hasattr(doc, "flags") and getattr(doc.flags, "skip_indonesia_hooks", False):
             return
-        
+
         # Only process if Indonesia payroll is enabled
         if cint(getattr(doc, "calculate_indonesia_tax", 0)) != 1:
             return
-        
+
         # Validate tax settings
         _validate_tax_settings(doc)
-        
+
         logger.debug(f"Completed validate for payroll entry {getattr(doc, 'name', 'unknown')}")
-    
+
     except Exception as e:
         logger.exception(f"Error in validate: {str(e)}")
 
@@ -81,7 +83,7 @@ def validate(doc, method=None):
 def before_submit(doc, method=None):
     """
     Before submit hook for Payroll Entry.
-    
+
     Args:
         doc: Payroll Entry document
         method: Method name (not used)
@@ -90,21 +92,50 @@ def before_submit(doc, method=None):
         # Skip if document is already processed
         if hasattr(doc, "flags") and getattr(doc.flags, "skip_indonesia_hooks", False):
             return
-        
+
         # Only process if Indonesia payroll is enabled
         if cint(getattr(doc, "calculate_indonesia_tax", 0)) != 1:
             return
-        
+
         logger.debug(f"Completed before_submit for payroll entry {getattr(doc, 'name', 'unknown')}")
-    
+
     except Exception as e:
         logger.exception(f"Error in before_submit: {str(e)}")
+
+
+def on_submit(doc, method=None):
+    """On submit hook for Payroll Entry."""
+    try:
+        if hasattr(doc, "flags") and getattr(doc.flags, "skip_indonesia_hooks", False):
+            return
+
+        if cint(getattr(doc, "calculate_indonesia_tax", 0)) != 1:
+            return
+
+        doc.create_salary_slips()
+
+        try:
+            doc.submit_salary_slips()
+        except Exception as submit_error:
+            logger.warning(f"Failed to submit salary slips: {str(submit_error)}")
+            frappe.log_error(
+                f"Failed to submit salary slips: {str(submit_error)}",
+                "Salary Slip Submission Error",
+            )
+
+        logger.info(
+            f"Created salary slips on submit for payroll entry {getattr(doc, 'name', 'unknown')}"
+        )
+
+    except Exception as e:
+        logger.exception(f"Error in on_submit: {str(e)}")
+        frappe.log_error(f"Error in on_submit: {str(e)}", "Payroll Entry on_submit")
 
 
 def after_submit(doc, method=None):
     """
     After submit hook for Payroll Entry.
-    
+
     Args:
         doc: Payroll Entry document
         method: Method name (not used)
@@ -113,13 +144,13 @@ def after_submit(doc, method=None):
         # Skip if document is already processed
         if hasattr(doc, "flags") and getattr(doc.flags, "skip_indonesia_hooks", False):
             return
-        
+
         # Only process if Indonesia payroll is enabled
         if cint(getattr(doc, "calculate_indonesia_tax", 0)) != 1:
             return
-        
+
         logger.debug(f"Completed after_submit for payroll entry {getattr(doc, 'name', 'unknown')}")
-    
+
     except Exception as e:
         logger.exception(f"Error in after_submit: {str(e)}")
 
@@ -127,7 +158,7 @@ def after_submit(doc, method=None):
 def _check_december_override(doc):
     """
     Check and set December override flag if needed.
-    
+
     Args:
         doc: Payroll Entry document
     """
@@ -135,38 +166,42 @@ def _check_december_override(doc):
         # Get start and end dates
         start_date = getattr(doc, "start_date", None)
         end_date = getattr(doc, "end_date", None)
-        
+
         if not start_date or not end_date:
             return
-        
+
         # Convert to date objects
         start_date = getdate(start_date)
         end_date = getdate(end_date)
-        
+
         # Check if December is included
-        is_december = (start_date.month == 12 or end_date.month == 12)
-        
+        is_december = start_date.month == 12 or end_date.month == 12
+
         # If December is included, check if we should auto-set the override flag
         if is_december:
             # Check if auto-set is enabled in settings
             settings = frappe.get_cached_doc("Payroll Indonesia Settings")
             auto_set_december = cint(getattr(settings, "auto_set_december_override", 0))
-            
+
             if auto_set_december:
                 # Only set if not already set
                 if not hasattr(doc, "is_december_override") or not doc.is_december_override:
                     doc.is_december_override = 1
-                    logger.debug(f"Auto-set December override flag for payroll entry {getattr(doc, 'name', 'unknown')}")
-            
+                    logger.debug(
+                        f"Auto-set December override flag for payroll entry {getattr(doc, 'name', 'unknown')}"
+                    )
+
             # If manual setting and December, show a message
             elif not getattr(doc, "is_december_override", 0):
                 frappe.msgprint(
-                    _("This payroll period includes December. Consider enabling the 'December Override' "
-                      "flag for year-end tax adjustments."),
+                    _(
+                        "This payroll period includes December. Consider enabling the 'December Override' "
+                        "flag for year-end tax adjustments."
+                    ),
                     title=_("December Payroll"),
-                    indicator="blue"
+                    indicator="blue",
                 )
-    
+
     except Exception as e:
         logger.exception(f"Error checking December override: {str(e)}")
 
@@ -174,7 +209,7 @@ def _check_december_override(doc):
 def _validate_tax_settings(doc):
     """
     Validate tax-related settings.
-    
+
     Args:
         doc: Payroll Entry document
     """
@@ -183,14 +218,14 @@ def _validate_tax_settings(doc):
         tax_method = getattr(doc, "tax_method", "Progressive")
         if tax_method not in ["Progressive", "TER"]:
             frappe.throw(_("Invalid tax method. Must be 'Progressive' or 'TER'."))
-        
+
         # If using TER, ensure TER settings are defined
         if tax_method == "TER":
             _validate_ter_settings()
-        
+
         # Validate that all salary structures have components with defined tax effects
         _validate_component_tax_effects(doc)
-    
+
     except Exception as e:
         logger.exception(f"Error validating tax settings: {str(e)}")
 
@@ -201,32 +236,34 @@ def _validate_ter_settings():
     """
     try:
         settings = frappe.get_cached_doc("Payroll Indonesia Settings")
-        
+
         # Check if TER rates are defined
         has_ter_rates = False
-        
+
         # Check for ter_rates_json
         if hasattr(settings, "ter_rates_json") and settings.ter_rates_json:
             has_ter_rates = True
-        
+
         # Check for ter_rate_table
         if hasattr(settings, "ter_rate_table") and settings.ter_rate_table:
             has_ter_rates = True
-        
+
         # Check config as fallback
         if not has_ter_rates:
             cfg = get_live_config()
             ter_rates = cfg.get("tax", {}).get("ter_rates", {})
             if ter_rates:
                 has_ter_rates = True
-        
+
         if not has_ter_rates:
             frappe.throw(
-                _("TER rates are not defined in Payroll Indonesia Settings. "
-                  "Please define TER rates before using TER method."),
-                title=_("Missing TER Rates")
+                _(
+                    "TER rates are not defined in Payroll Indonesia Settings. "
+                    "Please define TER rates before using TER method."
+                ),
+                title=_("Missing TER Rates"),
             )
-    
+
     except Exception as e:
         logger.exception(f"Error validating TER settings: {str(e)}")
 
@@ -234,71 +271,67 @@ def _validate_ter_settings():
 def _validate_component_tax_effects(doc):
     """
     Validate that components in salary structures have tax effects defined.
-    
+
     Args:
         doc: Payroll Entry document
     """
     try:
         # Get salary structures used in this payroll entry
         structures = set()
-        
+
         if hasattr(doc, "employees") and doc.employees:
             for employee in doc.employees:
                 if employee.salary_structure:
                     structures.add(employee.salary_structure)
-        
+
         if not structures:
             return
-        
+
         # Check components in each structure
         missing_effects = []
-        
+
         for structure_name in structures:
             try:
                 structure = frappe.get_doc("Salary Structure", structure_name)
-                
+
                 # Check earnings
                 if hasattr(structure, "earnings") and structure.earnings:
                     for earning in structure.earnings:
                         component = earning.salary_component
                         tax_effect = get_component_tax_effect(component, "Earning")
-                        
+
                         if not tax_effect:
                             missing_effects.append(f"Earning: {component} (in {structure_name})")
-                
+
                 # Check deductions
                 if hasattr(structure, "deductions") and structure.deductions:
                     for deduction in structure.deductions:
                         component = deduction.salary_component
-                        
+
                         # Skip PPh 21 component
                         if component == "PPh 21":
                             continue
-                        
+
                         tax_effect = get_component_tax_effect(component, "Deduction")
-                        
+
                         if not tax_effect:
                             missing_effects.append(f"Deduction: {component} (in {structure_name})")
-            
+
             except Exception as e:
                 logger.warning(f"Error checking structure {structure_name}: {str(e)}")
-        
+
         # Show warning if components are missing tax effects
         if missing_effects:
             warning_msg = _(
                 "The following components are missing tax effect settings. "
                 "They will be treated as non-taxable by default:\n{0}"
             ).format("\n".join(missing_effects[:10]))
-            
+
             # If more than 10, show count
             if len(missing_effects) > 10:
                 warning_msg += _("\n...and {0} more components").format(len(missing_effects) - 10)
-            
-            frappe.msgprint(
-                warning_msg,
-                title=_("Missing Tax Effect Settings"),
-                indicator="orange"
-            )
-    
+
+            frappe.msgprint(warning_msg, title=_("Missing Tax Effect Settings"), indicator="orange")
+
     except Exception as e:
         logger.exception(f"Error validating component tax effects: {str(e)}")


### PR DESCRIPTION
## Summary
- register Payroll Entry doc event hooks
- generate salary slips when Payroll Entry is submitted
- document automatic creation feature in README and CHANGELOG

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68775054bde0832cac82cf34c83a9253