### PR TITLE
Add data sanitization helper for updates

### DIFF
--- a/payroll_indonesia/api.py
+++ b/payroll_indonesia/api.py
@@ -29,6 +29,7 @@ from payroll_indonesia.payroll_indonesia.doctype.bpjs_payment_summary.bpjs_payme
     get_employee_bpjs_details,
     get_summary_for_period,
 )
+from payroll_indonesia.utilities import sanitize_update_data
 
 logger = logging.getLogger("payroll_api")
 
@@ -213,11 +214,20 @@ def reconcile_payment_journal(
         # Create service instance
         service = BPJSPaymentService()
 
+        # Sanitize input before passing to service
+        params = sanitize_update_data(
+            {
+                "payment_summary": payment_summary,
+                "journal_entry": journal_entry,
+                "payment_entry": payment_entry,
+            }
+        )
+
         # Delegate to service layer
         result = service.reconcile_payment_journal(
-            payment_summary=payment_summary,
-            journal_entry=journal_entry,
-            payment_entry=payment_entry,
+            payment_summary=params.get("payment_summary"),
+            journal_entry=params.get("journal_entry"),
+            payment_entry=params.get("payment_entry"),
         )
 
         # Return result

--- a/payroll_indonesia/payroll_indonesia/doctype/bpjs_payment_summary/bpjs_payment_service.py
+++ b/payroll_indonesia/payroll_indonesia/doctype/bpjs_payment_summary/bpjs_payment_service.py
@@ -22,6 +22,7 @@ from frappe.utils import cint, flt, get_datetime, today, now_datetime
 from payroll_indonesia.payroll_indonesia.doctype.bpjs_payment_summary.payment_summary_service_core import (
     PaymentSummaryService,
 )
+from payroll_indonesia.utilities import sanitize_update_data
 
 logger = logging.getLogger("bpjs_payment_services")
 
@@ -216,8 +217,19 @@ class BPJSPaymentService:
                 _(f"BPJS Payment Summary {payment_summary} must be submitted before reconciliation")
             )
 
+        # Sanitize input fields
+        update_fields = sanitize_update_data(
+            {
+                "journal_entry": journal_entry,
+                "payment_entry": payment_entry,
+            }
+        )
+
         # Update references
         changed = False
+
+        journal_entry = update_fields.get("journal_entry")
+        payment_entry = update_fields.get("payment_entry")
 
         if journal_entry and doc.journal_entry != journal_entry:
             doc.db_set("journal_entry", journal_entry)

--- a/payroll_indonesia/payroll_indonesia/doctype/bpjs_payment_summary/payment_summary_service_core.py
+++ b/payroll_indonesia/payroll_indonesia/doctype/bpjs_payment_summary/payment_summary_service_core.py
@@ -18,6 +18,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union, cast
 import frappe
 from frappe import _
 from frappe.utils import cint, flt, get_datetime, today, now_datetime
+from payroll_indonesia.utilities import sanitize_update_data
 
 from payroll_indonesia.payroll_indonesia.doctype.bpjs_payment_summary.bpjs_payment_utils import (
     safe_decimal,
@@ -126,7 +127,9 @@ class PaymentSummaryService:
 
         # Commit changes to database if this is a saved document
         if self.doc.name and not self.doc.is_new():
-            self.doc.db_set("total", total, update_modified=False)
+            data = sanitize_update_data({"total": total})
+            if "total" in data:
+                self.doc.db_set("total", total, update_modified=False)
 
         return total
 
@@ -215,8 +218,13 @@ class PaymentSummaryService:
 
             # Update database directly
             if not self.doc.is_new():
-                self.doc.db_set("payment_entry", payment_entry.name)
-                self.doc.db_set("status", "Paid")
+                data = sanitize_update_data(
+                    {"payment_entry": payment_entry.name, "status": "Paid"}
+                )
+                if "payment_entry" in data:
+                    self.doc.db_set("payment_entry", payment_entry.name)
+                if "status" in data:
+                    self.doc.db_set("status", "Paid")
 
             debug_log(f"Created Payment Entry {payment_entry.name} for {self.doc.name}")
             return payment_entry.name
@@ -332,7 +340,9 @@ class PaymentSummaryService:
 
             # Update database directly
             if not self.doc.is_new():
-                self.doc.db_set("journal_entry", journal_entry.name)
+                data = sanitize_update_data({"journal_entry": journal_entry.name})
+                if "journal_entry" in data:
+                    self.doc.db_set("journal_entry", journal_entry.name)
 
             debug_log(f"Created Journal Entry {journal_entry.name} for {self.doc.name}")
             return journal_entry.name

--- a/payroll_indonesia/payroll_indonesia/tests/test_update_utils.py
+++ b/payroll_indonesia/payroll_indonesia/tests/test_update_utils.py
@@ -1,0 +1,31 @@
+import types
+import importlib
+
+from payroll_indonesia.utilities import sanitize_update_data
+
+
+class DummyDoc:
+    def __init__(self):
+        self.updated = {}
+
+    def db_set(self, key, value):
+        if key == "creation":
+            raise Exception("CannotChangeConstantError")
+        self.updated[key] = value
+
+
+def test_sanitize_update_data_removes_creation():
+    data = {"name": "DOC-1", "creation": "2024-01-01", "value": 1}
+    result = sanitize_update_data(data)
+    assert "creation" not in result
+    assert result["name"] == "DOC-1"
+    assert result["value"] == 1
+
+
+def test_update_with_sanitized_data_does_not_raise():
+    doc = DummyDoc()
+    update = {"journal_entry": "JE-1", "creation": "2024-01-01"}
+    sanitized = sanitize_update_data(update)
+    for key, val in sanitized.items():
+        doc.db_set(key, val)
+    assert doc.updated == {"journal_entry": "JE-1"}

--- a/payroll_indonesia/utilities/__init__.py
+++ b/payroll_indonesia/utilities/__init__.py
@@ -1,1 +1,5 @@
 __version__ = "0.0.1"
+
+from .update_utils import sanitize_update_data
+
+__all__ = ["sanitize_update_data"]

--- a/payroll_indonesia/utilities/update_utils.py
+++ b/payroll_indonesia/utilities/update_utils.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+"""Utility helpers for updating documents safely."""
+
+from typing import Any, Dict
+
+
+def sanitize_update_data(data: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a copy of ``data`` without immutable fields.
+
+    Keys like ``creation`` or ``creation_on`` should never be passed to
+    update functions as they would trigger ``CannotChangeConstantError`` in
+    Frappe. This helper strips such keys before database operations.
+
+    Args:
+        data: Mapping of fields to update.
+
+    Returns:
+        Sanitized copy of ``data`` with disallowed keys removed.
+    """
+    if not isinstance(data, dict):
+        return {}
+
+    blocked_keys = {
+        "creation",
+        "creation_on",
+        "modified",
+        "modified_by",
+        "modified_on",
+        "owner",
+        "doctype",
+        "idx",
+    }
+
+    return {k: v for k, v in data.items() if k not in blocked_keys}


### PR DESCRIPTION
## Summary
- provide `sanitize_update_data` helper
- sanitize update parameters in API and services
- ensure db updates ignore creation fields
- test sanitize logic with dummy doc

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68779776e33c832cbe50f779b85870ff