### PR TITLE
Parameterize site reference

### DIFF
--- a/scripts/debug_pph21_route.py
+++ b/scripts/debug_pph21_route.py
@@ -3,10 +3,26 @@ from __future__ import annotations
 import frappe
 
 from payroll_indonesia.payroll_indonesia import salary_slip_functions as ssf
+import argparse
+import os
 
 
 def main() -> None:
-    frappe.connect(site="itb_dev_lokal")  # ganti site Anda
+    parser = argparse.ArgumentParser(description="Debug PPh21 route")
+    parser.add_argument(
+        "--site",
+        default=os.getenv("FRAPPE_SITE"),
+        help="Frappe site name or set FRAPPE_SITE env variable",
+    )
+    args = parser.parse_args()
+    site = args.site
+
+    if not site:
+        parser.print_usage()
+        print("error: site must be provided via --site or FRAPPE_SITE")
+        return
+
+    frappe.connect(site=site)
 
     # 1. Ensure settings
     settings = frappe.get_cached_doc("Payroll Indonesia Settings")


### PR DESCRIPTION
## Summary
- add CLI argument parsing for scripts/debug_pph21_route.py
- read site from `--site` or `FRAPPE_SITE`

## Testing
- `./scripts/install_dependencies.sh` *(fails: could not download packages)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878a5d2b304832ca6e6e88a5389562f