### PR TITLE
Implement tax cleanup when Salary Slip cancelled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,4 @@
 - Salary slip creation now forces `tax_calculation_method` to "Manual" and clears `income_tax_slab`.
 - Renamed `use_ter_method` field on Payroll Entry to `ter_method_enabled`.
 - Payroll Entry submission now automatically creates and submits Salary Slips.
+- Cancelling a Payroll Entry now clears tax data so a new payroll entry for the same period can be submitted.

--- a/payroll_indonesia/hooks.py
+++ b/payroll_indonesia/hooks.py
@@ -42,6 +42,7 @@ doc_events = {
         "validate": "payroll_indonesia.override.salary_slip_functions.validate",
         "before_save": "payroll_indonesia.override.salary_slip_functions.before_save",
         "after_save": "payroll_indonesia.override.salary_slip_functions.after_save",
+        "on_cancel": "payroll_indonesia.override.salary_slip_functions.on_cancel",
         "after_submit": "payroll_indonesia.override.salary_slip_functions.after_submit",
     },
     "BPJS Account Mapping": {

--- a/payroll_indonesia/override/salary_slip_functions.py
+++ b/payroll_indonesia/override/salary_slip_functions.py
@@ -36,6 +36,9 @@ from payroll_indonesia.override.salary_slip.controller import (
 )
 from payroll_indonesia.frappe_helpers import logger
 from payroll_indonesia.payroll_indonesia import utils
+from payroll_indonesia.payroll_indonesia.doctype.employee_tax_summary.employee_tax_summary import (
+    reset_from_cancelled_slip,
+)
 
 
 def before_validate(doc, method=None):
@@ -510,3 +513,21 @@ def get_component_details(slip, component_name):
     except Exception as e:
         logger.exception(f"Error getting component details for {component_name}: {str(e)}")
         return {"found": False, "type": None, "amount": 0.0, "tax_effect": None}
+
+
+def on_cancel(doc, method=None):
+    """Handle Salary Slip cancellation."""
+    try:
+        if cint(getattr(doc, "calculate_indonesia_tax", 0)) != 1:
+            return
+
+        try:
+            reset_from_cancelled_slip(doc.name)
+            logger.info(f"Reset tax summary from cancelled slip {doc.name}")
+        except Exception:
+            logger.exception(
+                f"Error resetting tax summary from cancelled slip {doc.name}"
+            )
+
+    except Exception as e:
+        logger.exception(f"Error in on_cancel: {str(e)}")


### PR DESCRIPTION
## Summary
- handle Salary Slip cancellation
- wire cancellation hook
- document cancellation behavior in changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bcea279e4832c88d439ba4b126ee0