### PR TITLE
Add safe exec globals hook

### DIFF
--- a/payroll_indonesia/__init__.py
+++ b/payroll_indonesia/__init__.py
@@ -1,16 +1,1 @@
 __version__ = "1.0.0"
-
-# Ensure Python built-ins ``min`` and ``max`` are available during formula
-# evaluation in Salary Structure and Salary Slip.  ERPNext's safe execution
-# environment does not expose these by default which causes evaluation errors
-# for formulas like ``min(base, cap)``.  If frappe is not installed the import
-# will fail (for example when running static analysis), therefore wrap the
-# update in ``try/except``.
-try:  # pragma: no cover - frappe might not be available during tests
-    from frappe.utils.safe_exec import get_safe_globals
-
-    safe_globals = get_safe_globals()
-    safe_globals.setdefault("min", min)
-    safe_globals.setdefault("max", max)
-except Exception:
-    pass

--- a/payroll_indonesia/hooks.py
+++ b/payroll_indonesia/hooks.py
@@ -5,6 +5,12 @@ app_description = "Payroll Indonesia - Modul Perhitungan BPJS & PPh 21 untuk ERP
 app_email = "hello@imogi.tech"
 app_license = "MIT"
 
+# Python built-ins exposed in Frappe's safe execution environment
+safe_exec_globals = {
+    "min": "builtins.min",
+    "max": "builtins.max",
+}
+
 # Includes in <head>
 # ------------------
 

--- a/payroll_indonesia/override/salary_slip.py
+++ b/payroll_indonesia/override/salary_slip.py
@@ -8,27 +8,6 @@ import frappe
 from payroll_indonesia.config import pph21_ter, pph21_ter_december
 from payroll_indonesia.utils import sync_annual_payroll_history
 
-# --- Ensure min/max are available for formula evaluation globally in ERPNext ---
-def patch_safe_globals():
-    """
-    Patch frappe safe_exec globals to include min/max for formula evaluation.
-    This works for Salary Component/Structure formulas using min/max.
-    """
-    try:
-        from frappe.utils.safe_exec import get_safe_globals
-
-        safe_globals = get_safe_globals()
-        # Patch only if not already present
-        if "min" not in safe_globals:
-            safe_globals["min"] = min
-        if "max" not in safe_globals:
-            safe_globals["max"] = max
-    except Exception:
-        # If frappe not installed or get_safe_globals not available, ignore
-        pass
-
-patch_safe_globals()
-
 class CustomSalarySlip(SalarySlip):
     """
     Salary Slip with Indonesian income tax calculations (TER bulanan dan Progressive/Desember).


### PR DESCRIPTION
## Summary
- expose `min` and `max` to Frappe safe exec via hooks
- drop runtime patching in `__init__` and salary slip override

## Testing
- `python -m compileall -q payroll_indonesia`
- `pytest -q`
- ❌ `pip install frappe==15.5.0` *(fails: Cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6888c9936d08832ca1ea6b6dbf6f2f0a