### PR TITLE
feat: add salary slip fetch helper

### DIFF
--- a/payroll_indonesia/override/payroll_entry.py
+++ b/payroll_indonesia/override/payroll_entry.py
@@ -42,6 +42,12 @@ class CustomPayrollEntry(PayrollEntry):
             result = super().create_salary_slips()
             return result if result is not None else []
 
+    def get_salary_slips(self):
+        """Return list of Salary Slip names linked to this Payroll Entry."""
+        return frappe.get_all(
+            "Salary Slip", filters={"payroll_entry": self.name}, pluck="name"
+        )
+
     def _create_salary_slips_indonesia(self):
         """
         Generate salary slips with PPh21 TER (monthly) logic.

--- a/payroll_indonesia/tests/test_payroll_entry_get_salary_slips.py
+++ b/payroll_indonesia/tests/test_payroll_entry_get_salary_slips.py
@@ -1,0 +1,71 @@
+import sys
+import os
+import types
+import importlib
+
+
+def test_get_salary_slips(monkeypatch):
+    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+    # --- Frappe stubs -----------------------------------------------------
+    frappe = types.ModuleType("frappe")
+    utils_mod = types.ModuleType("frappe.utils")
+    safe_exec_mod = types.ModuleType("frappe.utils.safe_exec")
+
+    class DummyLogger:
+        def info(self, msg):
+            pass
+        def warning(self, msg):
+            pass
+        def error(self, msg):
+            pass
+
+    def logger():
+        return DummyLogger()
+
+    def flt(val, precision=None):
+        return float(val)
+
+    def safe_eval(expr, context=None):
+        return eval(expr, context or {})
+
+    # get_all will be used by get_salary_slips
+    def get_all(doctype, filters=None, pluck=None):
+        assert doctype == "Salary Slip"
+        assert filters == {"payroll_entry": "PE-0001"}
+        assert pluck == "name"
+        return ["SS1", "SS2"]
+
+    frappe.get_all = get_all
+    frappe.get_doc = lambda *args, **kwargs: {}
+    frappe.get_cached_doc = frappe.get_doc
+    frappe.throw = lambda *args, **kwargs: None
+    frappe.utils = utils_mod
+    frappe.logger = logger
+    utils_mod.flt = flt
+    utils_mod.safe_exec = safe_exec_mod
+    safe_exec_mod.safe_eval = safe_eval
+
+    sys.modules["frappe"] = frappe
+    sys.modules["frappe.utils"] = utils_mod
+    sys.modules["frappe.utils.safe_exec"] = safe_exec_mod
+
+    payroll_entry = importlib.import_module("payroll_indonesia.override.payroll_entry")
+    CustomPayrollEntry = payroll_entry.CustomPayrollEntry
+
+    entry = CustomPayrollEntry()
+    entry.name = "PE-0001"
+
+    slips = entry.get_salary_slips()
+    assert slips == ["SS1", "SS2"]
+
+    # Cleanup modules so other tests import fresh versions
+    for mod in [
+        "frappe",
+        "frappe.utils",
+        "frappe.utils.safe_exec",
+        "payroll_indonesia.override.payroll_entry",
+        "payroll_indonesia.override.salary_slip",
+    ]:
+        sys.modules.pop(mod, None)
+


### PR DESCRIPTION
## Summary
- add `get_salary_slips` helper to `CustomPayrollEntry`
- cover salary slip fetch logic with tests

## Testing
- `pytest`
- `pre-commit run --files payroll_indonesia/override/payroll_entry.py payroll_indonesia/tests/test_payroll_entry_get_salary_slips.py` *(fails: command not found; could not install pre-commit)*

------
https://chatgpt.com/codex/tasks/task_e_688b6c28b2e0832cae1b77ce9c945d91