### PR TITLE
Use Frappe make_autoname for payroll history

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -50,8 +50,14 @@ model_mod = types.ModuleType("frappe.model")
 document_mod = types.ModuleType("frappe.model.document")
 document_mod.Document = type("Document", (object,), {})
 model_mod.document = document_mod
+frappe.model = model_mod
 sys.modules.setdefault("frappe.model", model_mod)
 sys.modules.setdefault("frappe.model.document", document_mod)
+# Provide minimal implementation for frappe.model.naming.make_autoname used in tests
+naming_mod = types.ModuleType("frappe.model.naming")
+naming_mod.make_autoname = lambda value: value
+model_mod.naming = naming_mod
+sys.modules.setdefault("frappe.model.naming", naming_mod)
 payroll_entry_mod = types.ModuleType("hrms.payroll.doctype.payroll_entry.payroll_entry")
 payroll_entry_mod.PayrollEntry = type("PayrollEntry", (object,), {})
 sys.modules.setdefault("hrms.payroll.doctype.payroll_entry.payroll_entry", payroll_entry_mod)

--- a/payroll_indonesia/utils/sync_annual_payroll_history.py
+++ b/payroll_indonesia/utils/sync_annual_payroll_history.py
@@ -9,6 +9,7 @@ except Exception:  # pragma: no cover - fallback for test stubs without cint
             return int(value)
         except Exception:
             return 0
+from frappe.model.naming import make_autoname
 
 
 def get_or_create_annual_payroll_history(employee_name, fiscal_year, create_if_missing=True):
@@ -35,10 +36,9 @@ def get_or_create_annual_payroll_history(employee_name, fiscal_year, create_if_m
     history.employee = employee_name
     history.fiscal_year = fiscal_year
 
-    # Set name ke kombinasi unik employee-fiscal_year jika skema doctype mendukung
-    # Catatan: Ini hanya akan berhasil jika Annual Payroll History DocType dikonfigurasi
-    # untuk menerima nama kustom (autoname: format:{employee}-{fiscal_year} atau prompt)
-    history.name = f"{employee_name}-{fiscal_year}"
+    # Gunakan utilitas penamaan Frappe untuk membuat nama unik berdasarkan pola yang diinginkan
+    # Depend pada konfigurasi DocType atau pola yang diberikan agar menghasilkan identifier valid
+    history.name = make_autoname(f"{employee_name}-{fiscal_year}")
     
     return history
 


### PR DESCRIPTION
## Summary
- ensure Annual Payroll History names are generated via Frappe's naming utility
- stub `make_autoname` in tests and adjust test expectations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e396b69c0832ca0dc4889981b35f6